### PR TITLE
Potential fix for code scanning alert no. 3: Flask app is run in debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
-import os, time
+import os
+import time
 from datetime import datetime
 from pathlib import Path
 from uuid import uuid4
@@ -258,4 +259,5 @@ def internal(err):
 
 if __name__ == '__main__':
     logger.info("Flask app starting")
-    app.run(host='0.0.0.0', port=5000, debug=True, request_handler=SafeRequestHandler)
+    debug_mode = os.getenv('FLASK_DEBUG', 'false').lower() == 'true'
+    app.run(host='0.0.0.0', port=5000, debug=debug_mode, request_handler=SafeRequestHandler)


### PR DESCRIPTION
Potential fix for [https://github.com/Ilhanemreadak/dna_encryption_algorithm/security/code-scanning/3](https://github.com/Ilhanemreadak/dna_encryption_algorithm/security/code-scanning/3)

To fix the issue, we will ensure that the Flask application does not run in debug mode by default. Instead, we will use an environment variable (e.g., `FLASK_DEBUG`) to control whether debug mode is enabled. This approach ensures that debug mode is only enabled explicitly for development environments and remains disabled in production.

Steps to implement the fix:
1. Import the `os` module if not already imported.
2. Replace the hardcoded `debug=True` argument in `app.run()` with a dynamic value based on the `FLASK_DEBUG` environment variable.
3. Set `debug=False` as the default if the environment variable is not set, ensuring that debug mode is disabled by default.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
